### PR TITLE
opt getTbSkin

### DIFF
--- a/app/src/main/java/gm/tieba/tabswitch/util/DisplayUtils.java
+++ b/app/src/main/java/gm/tieba/tabswitch/util/DisplayUtils.java
@@ -5,7 +5,11 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
 
-public class DisplayUtils {
+import de.robv.android.xposed.XposedBridge;
+import de.robv.android.xposed.XposedHelpers;
+import gm.tieba.tabswitch.XposedContext;
+
+public class DisplayUtils extends XposedContext {
     public static boolean isLightMode(final Context context) {
         return (context.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK)
                 == Configuration.UI_MODE_NIGHT_NO;
@@ -22,19 +26,29 @@ public class DisplayUtils {
     }
 
     public static String getTbSkin(final Context context) {
-        final var settings = context.getSharedPreferences("settings", Context.MODE_PRIVATE);
-        if (settings.getBoolean("key_is_follow_system_mode", false)) {
-            return isLightMode(context) ? "" : "_2";
-        } else {
-            final var commonSettings = context.getSharedPreferences(
-                    "common_settings", Context.MODE_PRIVATE);
-            switch (commonSettings.getString("skin_", "0")) {
-                case "4":
-                    return "_2";
-                case "0":
-                default:
-                    return "";
+        //Lcom/baidu/tbadk/core/TbadkCoreApplication;->getSkinType()I
+        int skinType;
+        try {
+            Object instance = XposedHelpers.callStaticMethod(XposedHelpers.findClass("com.baidu.tbadk.core.TbadkCoreApplication", sClassLoader), "getInst");
+            skinType = (int) XposedHelpers.callMethod(instance, "getSkinType");
+        } catch (Exception e) {
+            XposedBridge.log(e);
+            final var settings = context.getSharedPreferences("settings", Context.MODE_PRIVATE);
+            if (settings.getBoolean("key_is_follow_system_mode", false)) {
+                return isLightMode(context) ? "" : "_2";
+            } else {
+                final var commonSettings = context.getSharedPreferences(
+                        "common_settings", Context.MODE_PRIVATE);
+                skinType = Integer.parseInt((commonSettings.getString("skin_", "0")));
             }
+        }
+        switch (skinType) {
+            case 1:
+            case 4:
+                return "_2";
+            case 0:
+            default:
+                return "";
         }
     }
 


### PR DESCRIPTION
优化getTbSkin，优先使用贴吧自身的getSkinType（相较而言最准确获取），因贴吧某些情况会导致isLightMode获得值改变（例如点我的-立即开通后）；skin_的值也不是完全准确，如打开跟随系统，切换系统深浅色后再冷启动贴吧，此值是不准确的，导致TS深浅色显示异常。补充了skin_值为1的情况，也是深色模式。

修改基于12.40.1.1版本。